### PR TITLE
Add struct tag support for Get operations to override the name that can be used for looking up a struct field

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,31 @@ fmt.Printf("%s", value)
 // Output:
 // Alice
 ```
+
+The library also supports `Get` operations on structs including using the `pointer`
+struct tag to override struct field names:
+
+```go
+	input := struct {
+		Values map[string]interface{} `pointer:"embedded"`
+	}{
+		Values: map[string]interface{}{
+			"alice": 42,
+			"bob": []interface{}{
+				map[string]interface{}{
+					"name": "Bob",
+				},
+			},
+		},
+	}
+
+	value, err := Get(input, "/embedded/bob/0/name")
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("%s", value)
+// Output:
+// Bob
+```
+

--- a/get_test.go
+++ b/get_test.go
@@ -11,15 +11,17 @@ func TestPointerGet(t *testing.T) {
 	type testIntType int
 
 	cases := []struct {
-		Name   string
-		Parts  []string
-		Input  interface{}
-		Output interface{}
-		Err    bool
+		Name    string
+		Parts   []string
+		TagName string
+		Input   interface{}
+		Output  interface{}
+		Err     bool
 	}{
 		{
 			"empty",
 			[]string{},
+			"",
 			42,
 			42,
 			false,
@@ -28,6 +30,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"nil",
 			nil,
+			"",
 			42,
 			42,
 			false,
@@ -36,6 +39,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"map key",
 			[]string{"foo"},
+			"",
 			map[string]interface{}{"foo": "bar"},
 			"bar",
 			false,
@@ -44,6 +48,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"map key type change",
 			[]string{"foo"},
+			"",
 			map[testStringType]interface{}{"foo": "bar"},
 			"bar",
 			false,
@@ -52,6 +57,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"map key type change non-string",
 			[]string{"42"},
+			"",
 			map[testIntType]interface{}{42: "bar"},
 			"bar",
 			false,
@@ -60,6 +66,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"map key missing",
 			[]string{"foo"},
+			"",
 			map[string]interface{}{"bar": "baz"},
 			nil,
 			true,
@@ -68,6 +75,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"map key number",
 			[]string{"42"},
+			"",
 			map[int]interface{}{42: "baz"},
 			"baz",
 			false,
@@ -76,6 +84,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"map recursive",
 			[]string{"foo", "42"},
+			"",
 			map[string]interface{}{
 				"foo": map[int]interface{}{
 					42: "baz",
@@ -88,6 +97,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"slice key",
 			[]string{"3"},
+			"",
 			[]interface{}{"a", "b", "c", "d", "e"},
 			"d",
 			false,
@@ -96,6 +106,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"slice key non-existent",
 			[]string{"7"},
+			"",
 			[]interface{}{"a", "b", "c", "d", "e"},
 			nil,
 			true,
@@ -104,6 +115,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"slice key below zero",
 			[]string{"-1"},
+			"",
 			[]interface{}{"a", "b", "c", "d", "e"},
 			nil,
 			true,
@@ -112,6 +124,7 @@ func TestPointerGet(t *testing.T) {
 		{
 			"array key",
 			[]string{"3"},
+			"",
 			&[5]interface{}{"a", "b", "c", "d", "e"},
 			"d",
 			false,
@@ -120,15 +133,73 @@ func TestPointerGet(t *testing.T) {
 		{
 			"struct key",
 			[]string{"Key"},
+			"",
 			&struct{ Key string }{Key: "foo"},
 			"foo",
 			false,
+		},
+
+		{
+			"struct tag",
+			[]string{"synthetic-name"},
+			"",
+			&struct {
+				Key string `pointer:"synthetic-name"`
+			}{Key: "foo"},
+			"foo",
+			false,
+		},
+
+		{
+			"struct tag alt name",
+			[]string{"synthetic-name"},
+			"altptr",
+			&struct {
+				Key   string `altptr:"synthetic-name"`
+				Other string `pointer:"synthetic-name"`
+			}{Key: "foo", Other: "bar"},
+			"foo",
+			false,
+		},
+
+		{
+			"struct tag ignore",
+			[]string{"Key"},
+			"altptr",
+			&struct {
+				Key string `altptr:"-"`
+			}{Key: "foo"},
+			"",
+			true,
+		},
+
+		{
+			"struct tag ignore and override",
+			[]string{"X"},
+			"",
+			&struct {
+				X string `pointer:"-"`
+				Y string `pointer:"X"`
+			}{X: "foo", Y: "bar"},
+			"bar",
+			false,
+		},
+
+		{
+			"struct tag invalid",
+			[]string{"synthetic,name"},
+			"",
+			&struct {
+				Key string `pointer:"synthetic,name"`
+			}{Key: "foo"},
+			"",
+			true,
 		},
 	}
 
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%d-%s", i, tc.Name), func(t *testing.T) {
-			p := &Pointer{Parts: tc.Parts}
+			p := &Pointer{Parts: tc.Parts, Config: Config{TagName: tc.TagName}}
 			actual, err := p.Get(tc.Input)
 			if (err != nil) != tc.Err {
 				t.Fatalf("err: %s", err)

--- a/pointer.go
+++ b/pointer.go
@@ -12,6 +12,12 @@ import (
 	"github.com/mitchellh/mapstructure"
 )
 
+type Config struct {
+	// The tag name that pointerstructure reads for field names. This
+	// defaults to "pointer"
+	TagName string
+}
+
 // Pointer represents a pointer to a specific value. You can construct
 // a pointer manually or use Parse.
 type Pointer struct {
@@ -19,6 +25,10 @@ type Pointer struct {
 	// The values are expected to be exact. If you have escape codes, use
 	// the Parse functions.
 	Parts []string
+
+	// Config is the configuration controlling how items are looked up
+	// in structures.
+	Config Config
 }
 
 // Get reads the value at the given pointer.
@@ -86,7 +96,8 @@ func (p *Pointer) Parent() *Pointer {
 	parts := make([]string, len(p.Parts)-1)
 	copy(parts, p.Parts[:len(p.Parts)-1])
 	return &Pointer{
-		Parts: parts,
+		Parts:  parts,
+		Config: p.Config,
 	}
 }
 


### PR DESCRIPTION
The format of the tag is `pointer:"<name>"`. The `,` and `|` characters are not allowed in the tag as they are reserved for future use of allowing options or multiple names.

TODO:
- [x] Documentation likely needs updating.