### PR TITLE
Add Defaults to support additional lexical scopes

### DIFF
--- a/get_test.go
+++ b/get_test.go
@@ -362,6 +362,42 @@ func TestPointerGet(t *testing.T) {
 			"",
 			true,
 		},
+
+		{
+			"Defaults is empty",
+			[]string{"foo"},
+			"",
+			Defaults{},
+			"bar",
+			true,
+		},
+
+		{
+			"Defaults found",
+			[]string{"foo"},
+			"",
+			Defaults{map[string]interface{}{"foo": "bar"}},
+			"bar",
+			false,
+		},
+
+		{
+			"Defaults overriden",
+			[]string{"foo"},
+			"",
+			Defaults{map[string]interface{}{"foo": "baz"}, map[string]interface{}{"foo": "bar"}},
+			"baz",
+			false,
+		},
+
+		{
+			"Defaults not found",
+			[]string{"var"},
+			"",
+			Defaults{map[string]interface{}{"foo": "baz"}, map[string]interface{}{"foo": "bar"}},
+			"",
+			true,
+		},
 	}
 
 	for i, tc := range cases {


### PR DESCRIPTION
This patch adds a Defaults and its support in Pointer.Get. When Defaults is received Pointer.Get will look for the target in the first element of Defaults and return it if it is found or go to the next element.

This makes it possible to support lexical scopes for the `any` and `all` loop constructs in go-bexpr and still have meaningful error messages when something is not found.